### PR TITLE
docs: note ComThread async pattern in _com.py

### DIFF
--- a/src/sapsucker/_com.py
+++ b/src/sapsucker/_com.py
@@ -28,6 +28,13 @@ Example::
             pythoncom.CoUninitialize()
 
     text = asyncio.run(asyncio.to_thread(_read_status_bar))
+
+For heavy async workloads (e.g. multiple parallel callers), consider a dedicated
+COM worker thread with a queue, retry logic for transient COM errors, and
+adaptive throttling.  The ``ComThread`` class in ``sapwebgui.mcp`` is a
+production-grade reference implementation of this pattern.  If a second async
+consumer of sapsucker emerges, extracting the core bridge into
+``sapsucker.aio`` would be worth revisiting.
 """
 
 # pylint: disable=import-outside-toplevel,invalid-name


### PR DESCRIPTION
## Summary
- Add a note to `_com.py`'s thread safety docstring pointing to sapwebgui.mcp's `ComThread` as a reference implementation for heavy async workloads
- Documents the decision to defer extracting into `sapsucker.aio` until a second async consumer appears

## Test plan
- [x] Docstring-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)