### PR TITLE
fix(login): close existing connections + verify client/user post-login

### DIFF
--- a/src/sapsucker/login.py
+++ b/src/sapsucker/login.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "cleanup_ghost_connections",
+    "close_connections_named",
     "discover_saplogon_path",
     "login",
     "logoff",
@@ -87,12 +88,17 @@ def login(
         timeout: Max seconds to wait for connection/session to become available.
 
     Returns:
-        A logged-in GuiSession.
+        A logged-in GuiSession whose ``info.client`` and ``info.user``
+        match the requested values.
 
     Raises:
         SapGuiTimeoutError: If SAP GUI or session doesn't become available.
         ScriptingDisabledError: If scripting is disabled on the server.
-        SapConnectionError: If login fails (wrong credentials, SAP error).
+        SapConnectionError: If login fails. This covers wrong credentials,
+            SAP error messages on the status bar, or the session ending up
+            in a different client / as a different user than requested
+            (e.g. because SSO or a cached logon ticket bypassed the
+            explicit credentials — see issue #24).
     """
     from sapsucker import SapGui  # pylint: disable=import-outside-toplevel
 
@@ -102,7 +108,16 @@ def login(
     except SapConnectionError:
         app = SapGui.launch(exe_path=saplogon_exe_path or discover_saplogon_path(), timeout=timeout)
 
-    # Step 2: Open connection
+    # Step 2a: Close any pre-existing connection sharing this description.
+    # ``OpenConnection(description)`` in SAP GUI Scripting returns an
+    # already-open connection by description rather than creating a fresh
+    # one; that would leave us with the prior session (wrong client/user)
+    # and the ``program == SAPMSYST`` guard below would skip the credential
+    # fill block entirely, silently misrouting the caller. Closing matches
+    # up-front forces a fresh SAPMSYST login dynpro — see issue #24.
+    close_connections_named(app, connection_name)
+
+    # Step 2b: Open connection
     conn = app.open_connection(connection_name, sync=True)
     session = wait_for_session(conn, timeout=timeout)
 
@@ -134,6 +149,30 @@ def login(
     if sbar is not None and cast(Any, sbar).message_type == "E":
         raise SapConnectionError(f"Login failed: {cast(Any, sbar).text}")
 
+    # Step 7: Verify we actually landed where we asked to. The Step 2a
+    # close-existing path handles the shared-``connection_name`` COM
+    # dedup case, but other routes to a wrong-client session exist —
+    # notably SSO/SNC or a cached logon ticket that auto-authenticates
+    # before we reach the SAPMSYST dynpro, causing the credential-fill
+    # block to be skipped entirely. In any such case we'd rather raise
+    # loudly here than hand back a session silently logged in as the
+    # wrong user or in the wrong client — see issue #24.
+    actual_client = str(session.info.client)
+    if actual_client != client:
+        raise SapConnectionError(
+            f"Login landed in client {actual_client!r} but {client!r} was requested. "
+            f"This usually means the SAP Logon entry {connection_name!r} was already "
+            "open in a different client and the per-call credential override did not "
+            "take effect."
+        )
+    actual_user = str(session.info.user)
+    if actual_user.upper() != user.upper():
+        raise SapConnectionError(
+            f"Login landed as user {actual_user!r} but {user!r} was requested. "
+            "This can happen when SSO/SNC or a cached logon ticket bypasses the "
+            "explicit credentials passed to login()."
+        )
+
     logger.info(
         "desktop_login",
         extra={"connection": connection_name, "user": user, "system": connection_name},
@@ -157,6 +196,41 @@ def logoff(session: GuiSession) -> None:
 
     # Clean up ghost connections (0 sessions) left behind
     cleanup_ghost_connections()
+
+
+def close_connections_named(app: Any, description: str) -> int:
+    """Close every open connection whose ``Description`` matches *description*.
+
+    Used by :func:`login` to force ``OpenConnection`` to create a fresh
+    connection rather than return an already-open one by name — see
+    issue #24. Safe to call directly from consumer code that needs the
+    same behaviour (e.g. to pre-clean before opening a second mandant
+    on the same SAP Logon entry).
+
+    Returns the number of connections actually closed. If SAP GUI is
+    not running, returns 0 without raising.
+
+    Uses reverse iteration over ``app.com.Children`` because the COM
+    ``GuiConnectionCollection`` mutates on close — the same reverse
+    pattern used by :func:`cleanup_ghost_connections` below.
+    """
+    closed = 0
+    try:
+        children = app.com.Children
+    except Exception:
+        return 0
+
+    for i in range(children.Count - 1, -1, -1):
+        try:
+            conn = children(i)
+            if str(conn.Description) == description:
+                conn.CloseConnection()
+                closed += 1
+        except Exception:
+            pass  # Best effort — never let cleanup mask the caller's real work
+    if closed:
+        logger.debug("close_connections_named", extra={"description": description, "closed": closed})
+    return closed
 
 
 def cleanup_ghost_connections() -> None:

--- a/unittests/test_login.py
+++ b/unittests/test_login.py
@@ -12,6 +12,7 @@ from sapsucker.login import (
     _FALLBACK_SAPLOGON_PATH,
     _handle_multiple_logon_popup,
     cleanup_ghost_connections,
+    close_connections_named,
     discover_saplogon_path,
     login,
     logoff,
@@ -19,10 +20,18 @@ from sapsucker.login import (
 )
 
 
-def _make_mock_session(program: str = "SAPMSYST", sbar_text: str = "", message_type: str = "") -> MagicMock:
+def _make_mock_session(
+    program: str = "SAPMSYST",
+    sbar_text: str = "",
+    message_type: str = "",
+    client: str = "100",
+    user: str = "TESTUSER",
+) -> MagicMock:
     """Create a mock GuiSession with info and find_by_id support."""
     session = MagicMock()
     session.info.program = program
+    session.info.client = client
+    session.info.user = user
 
     fields: dict[str, MagicMock] = {}
 
@@ -198,6 +207,262 @@ class TestLogin:
         )
 
         mock_sap_gui_cls.launch.assert_called_once()
+
+
+class TestLoginClosesExistingConnections:
+    """Regression coverage for issue #24.
+
+    ``login()`` must close any pre-existing connection sharing the
+    requested description BEFORE calling ``app.open_connection``,
+    otherwise ``OpenConnection`` returns the existing connection by
+    description and the credential-fill block is skipped — the caller
+    ends up silently routed to the prior session's client/user.
+    """
+
+    @patch("sapsucker.login.wait_for_session")
+    @patch("sapsucker.login.close_connections_named")
+    @patch("sapsucker.SapGui")
+    @patch("sapsucker.login.time")
+    def test_close_runs_before_open_connection(self, mock_time, mock_sap_gui_cls, mock_close, mock_wait):
+        """close_connections_named must be called before app.open_connection."""
+        session = _make_mock_session(program="SAPLSMTR_NAVIGATION", client="100", user="TESTUSER")
+        mock_wait.return_value = session
+        app = mock_sap_gui_cls.connect.return_value
+        call_order: list[str] = []
+
+        mock_close.side_effect = lambda _app, _desc: call_order.append("close") or 0
+        app.open_connection.side_effect = lambda *a, **kw: call_order.append("open") or MagicMock()
+
+        login(
+            connection_name="HF S/4",
+            client="100",
+            user="TESTUSER",
+            password="secret",
+        )
+
+        assert call_order == ["close", "open"]
+        mock_close.assert_called_once_with(app, "HF S/4")
+
+    @patch("sapsucker.login.wait_for_session")
+    @patch("sapsucker.login.close_connections_named")
+    @patch("sapsucker.SapGui")
+    @patch("sapsucker.login.time")
+    def test_close_returning_zero_is_fine(self, mock_time, mock_sap_gui_cls, mock_close, mock_wait):
+        """login() still proceeds normally when there are no matches to close."""
+        session = _make_mock_session(program="SAPLSMTR_NAVIGATION", client="100", user="TESTUSER")
+        mock_wait.return_value = session
+        mock_close.return_value = 0
+
+        result = login(
+            connection_name="FRESH",
+            client="100",
+            user="TESTUSER",
+            password="secret",
+        )
+
+        assert result is session
+
+    @patch("sapsucker.login.wait_for_session")
+    @patch("sapsucker.login.close_connections_named")
+    @patch("sapsucker.SapGui")
+    @patch("sapsucker.login.time")
+    def test_close_is_called_after_launch_path(self, mock_time, mock_sap_gui_cls, mock_close, mock_wait):
+        """close_connections_named also runs on the SAP-GUI-not-running launch path.
+
+        If SAP GUI was freshly launched there's nothing to close (returns 0),
+        but the *call* must still happen on the ``launch()``-returned app so
+        a subsequent reconnection attempt by the same consumer is consistent.
+        """
+        mock_sap_gui_cls.connect.side_effect = SapConnectionError("Not running")
+        session = _make_mock_session(program="SAPLSMTR_NAVIGATION", client="100", user="TESTUSER")
+        mock_wait.return_value = session
+        mock_close.return_value = 0
+
+        login(
+            connection_name="HF S/4",
+            client="100",
+            user="TESTUSER",
+            password="secret",
+        )
+
+        mock_close.assert_called_once()
+        # Called with the launched app, not the (failed) connect app
+        args, _ = mock_close.call_args
+        assert args[0] is mock_sap_gui_cls.launch.return_value
+        assert args[1] == "HF S/4"
+
+
+class TestLoginVerifiesClientAndUser:
+    """Regression coverage for issue #24.
+
+    After the SAPMSYST guard, ``login()`` must verify the resulting session
+    is actually in the requested client/user and raise ``SapConnectionError``
+    on mismatch instead of silently returning a wrong-Mandant session.
+    """
+
+    @patch("sapsucker.login.wait_for_session")
+    @patch("sapsucker.login.close_connections_named")
+    @patch("sapsucker.SapGui")
+    @patch("sapsucker.login.time")
+    def test_client_match_succeeds(self, mock_time, mock_sap_gui_cls, mock_close, mock_wait):
+        """Happy path: actual client matches requested → session returned."""
+        session = _make_mock_session(program="SAPLSMTR_NAVIGATION", client="210", user="MUSTERFRAUM")
+        mock_wait.return_value = session
+        mock_close.return_value = 0
+
+        result = login(
+            connection_name="HF S/4",
+            client="210",
+            user="MUSTERFRAUM",
+            password="secret",
+        )
+
+        assert result is session
+
+    @patch("sapsucker.login.wait_for_session")
+    @patch("sapsucker.login.close_connections_named")
+    @patch("sapsucker.SapGui")
+    @patch("sapsucker.login.time")
+    def test_client_mismatch_raises(self, mock_time, mock_sap_gui_cls, mock_close, mock_wait):
+        """If the new session lands in the wrong client, raise SapConnectionError."""
+        session = _make_mock_session(program="SAPLSMTR_NAVIGATION", client="100", user="MUSTERFRAUM")
+        mock_wait.return_value = session
+        mock_close.return_value = 0
+
+        with pytest.raises(SapConnectionError, match="Login landed in client '100' but '210' was requested"):
+            login(
+                connection_name="HF S/4",
+                client="210",
+                user="MUSTERFRAUM",
+                password="secret",
+            )
+
+    @patch("sapsucker.login.wait_for_session")
+    @patch("sapsucker.login.close_connections_named")
+    @patch("sapsucker.SapGui")
+    @patch("sapsucker.login.time")
+    def test_user_mismatch_raises(self, mock_time, mock_sap_gui_cls, mock_close, mock_wait):
+        """If the new session lands as the wrong user, raise SapConnectionError."""
+        session = _make_mock_session(program="SAPLSMTR_NAVIGATION", client="100", user="MUSTERMANNM")
+        mock_wait.return_value = session
+        mock_close.return_value = 0
+
+        with pytest.raises(
+            SapConnectionError, match="Login landed as user 'MUSTERMANNM' but 'MUSTERFRAUM' was requested"
+        ):
+            login(
+                connection_name="HF S/4",
+                client="100",
+                user="MUSTERFRAUM",
+                password="secret",
+            )
+
+    @patch("sapsucker.login.wait_for_session")
+    @patch("sapsucker.login.close_connections_named")
+    @patch("sapsucker.SapGui")
+    @patch("sapsucker.login.time")
+    def test_user_comparison_is_case_insensitive(self, mock_time, mock_sap_gui_cls, mock_close, mock_wait):
+        """SAP is case-insensitive about usernames — 'mustermannm' matches 'MUSTERMANNM'."""
+        session = _make_mock_session(program="SAPLSMTR_NAVIGATION", client="100", user="MUSTERMANNM")
+        mock_wait.return_value = session
+        mock_close.return_value = 0
+
+        # Lower-case request should succeed against upper-case server response
+        result = login(
+            connection_name="HF S/4",
+            client="100",
+            user="mustermannm",
+            password="secret",
+        )
+
+        assert result is session
+
+
+class TestCloseConnectionsNamedPublicAPI:
+    """close_connections_named must be exported as public API."""
+
+    def test_is_exported_in_all(self):
+        """Regression guard: the helper is exported so consumers can call it directly.
+
+        Removing it from ``__all__`` while leaving the function defined
+        would silently break consumers that did ``from sapsucker.login import *``
+        or relied on the documented public surface.
+        """
+        import sapsucker.login as login_mod  # pylint: disable=import-outside-toplevel
+
+        assert "close_connections_named" in login_mod.__all__
+
+
+class TestCloseConnectionsNamed:
+    """Direct unit tests for the close_connections_named helper."""
+
+    def _fake_app(self, descriptions: list[str]) -> MagicMock:
+        """Build a mock app whose ``com.Children`` mimics the SAP GUI COM collection."""
+        app = MagicMock()
+        children = MagicMock()
+        children.Count = len(descriptions)
+        conns: list[MagicMock] = []
+        for desc in descriptions:
+            conn = MagicMock()
+            conn.Description = desc
+            conns.append(conn)
+        children.side_effect = lambda i: conns[i]
+        app.com.Children = children
+        app._mock_conns = conns  # type: ignore[attr-defined]
+        return app
+
+    def test_closes_only_matching_connection(self):
+        """Entries with a different Description are left alone."""
+        app = self._fake_app(["HF S/4", "HFR3", "HF S/4"])
+
+        closed = close_connections_named(app, "HF S/4")
+
+        assert closed == 2
+        app._mock_conns[0].CloseConnection.assert_called_once()
+        app._mock_conns[1].CloseConnection.assert_not_called()
+        app._mock_conns[2].CloseConnection.assert_called_once()
+
+    def test_closes_zero_when_no_match(self):
+        app = self._fake_app(["HFR3", "OTHER"])
+
+        closed = close_connections_named(app, "HF S/4")
+
+        assert closed == 0
+        for conn in app._mock_conns:
+            conn.CloseConnection.assert_not_called()
+
+    def test_iterates_in_reverse(self):
+        """Reverse iteration is required because Children mutates on close.
+
+        Asserting access order catches a refactor that switches to forward
+        iteration — which would skip entries when the collection shrinks.
+        """
+        app = self._fake_app(["HF S/4", "HF S/4", "HF S/4"])
+        access_order: list[int] = []
+        app.com.Children.side_effect = lambda i: (access_order.append(i), app._mock_conns[i])[1]
+
+        close_connections_named(app, "HF S/4")
+
+        assert access_order == [2, 1, 0]
+
+    def test_close_failure_is_swallowed(self):
+        """A single failing CloseConnection must not abort the loop or raise."""
+        app = self._fake_app(["HF S/4", "HF S/4"])
+        app._mock_conns[1].CloseConnection.side_effect = RuntimeError("COM blew up")
+
+        closed = close_connections_named(app, "HF S/4")
+
+        # Reverse iteration hits index 1 first — its close raises and is swallowed.
+        # Index 0 still gets closed successfully, so the return value is 1.
+        assert closed == 1
+        app._mock_conns[0].CloseConnection.assert_called_once()
+
+    def test_children_access_failure_returns_zero(self):
+        """If ``app.com.Children`` itself blows up, return 0 without raising."""
+        app = MagicMock()
+        type(app.com).Children = property(lambda self: (_ for _ in ()).throw(RuntimeError("no COM")))
+
+        assert close_connections_named(app, "HF S/4") == 0
 
 
 class TestLogoff:


### PR DESCRIPTION
Fixes #24.

## Problem

When two sapsucker consumers share one SAP Logon entry across multiple mandants — e.g. a config with `"HF S/4 Mandant 100"` and `"HF S/4 Mandant 210"` both pointing at `connection_name="HF S/4"` — the second `login()` call silently returns the first entry's already-logged-in session. The caller ends up in the wrong client/user with no error.

**Working hypothesis** (consistent with the downstream symptom but not directly confirmed at the COM layer): `app.OpenConnection(description)` reuses an already-open connection by description rather than creating a fresh one. `wait_for_session()` then returns the prior session, which is already past the SAPMSYST login dynpro. The credential-fill guard `if session.info.program == "SAPMSYST":` in `login()` therefore skips the entire credential-typing block, and the caller's `client`/`user`/`password` are silently ignored.

The downstream bug report is Hochfrequenz/sapwebgui.mcp#659; a consumer-side workaround shipped in Hochfrequenz/sapwebgui.mcp#662 / v0.9.14. This PR puts the fix upstream so every sapsucker consumer benefits and the downstream workaround can be removed.

## Fix

Two changes inside `login()`, plus one new public helper:

### 1. Close matching connections before opening

Before `app.open_connection(connection_name)`, iterate `app.com.Children` in reverse and close every entry whose `Description` matches `connection_name`. Forces `OpenConnection` to land on a fresh SAPMSYST login dynpro so the credential-fill path runs as designed.

The close logic is exposed as a new public helper:

```python
def close_connections_named(app: Any, description: str) -> int:
    """Close every open connection whose Description matches description.

    Returns the number of connections closed. Safe to call directly
    from consumer code that needs the same behaviour (e.g. to pre-clean
    before opening a second mandant on the same SAP Logon entry).
    """
```

It uses the same reverse-iteration pattern as `cleanup_ghost_connections()` below (because the COM `Children` collection mutates on close).

### 2. Post-login client/user verification

After the existing SAPMSYST guard and status-bar error checks in `login()`, verify:
- `session.info.client == requested_client` (exact match)
- `session.info.user.upper() == requested_user.upper()` (case-insensitive — SAP usernames are ASCII and case-insensitive)

On mismatch, raise `SapConnectionError` with a clear message. This catches **any** route to a wrong-client session (SSO/SNC auto-login, cached logon ticket, a future regression in the credential-fill path) loudly rather than silently.

## Tests

27 tests in `unittests/test_login.py` (14 pre-existing + 13 new + 2 Windows-only skipped). New test classes:

- **`TestLoginClosesExistingConnections`** — wiring: close runs before `open_connection`, `connection_name` is forwarded verbatim, close helper also runs on the `SapGui.launch()` cold-start path.
- **`TestLoginVerifiesClientAndUser`** — happy path, client mismatch raises, user mismatch raises, user comparison is case-insensitive.
- **`TestCloseConnectionsNamed`** — direct unit tests on the helper: closes only matching descriptions, reverse iteration order (captured via `access_order` list), per-connection failures swallowed, `Children` access failure returns 0.
- **`TestCloseConnectionsNamedPublicAPI`** — regression guard that `close_connections_named` stays in `__all__`.

`_make_mock_session` gained `client` / `user` kwargs so existing tests pass the new verification; defaults match what those tests already expect at the call site.

## Public API impact (semver minor)

- **Signature of `login()`:** unchanged.
- **New public export:** `close_connections_named` added to `sapsucker.login.__all__`.
- **New trigger conditions** for the already-documented `SapConnectionError` raise from `login()`: now also raised when the resulting session lands in a different client or as a different user than requested. The error *type* is not new — the `Raises:` block already listed `SapConnectionError`. The docstring has been expanded to mention the new triggers explicitly.

**Behavioural note worth flagging:** `login()` now **always closes any open connection whose `Description` matches the requested `connection_name`** before opening the new one. In the normal sapsucker usage pattern (one entry → one connection) this is a no-op. A consumer that intentionally kept a long-lived connection open on that name and then called `login()` expecting a second parallel connection on the same name will find the long-lived one closed. That's unusual but not impossible — calling it out here so anyone doing something unusual has a chance to react. The pre-fix behaviour in that case was already broken (you'd get the existing session back, not a new one), so no realistic consumer can be *relying* on the old path.

## Checklist

- [x] `pytest unittests/test_login.py` — 27 passed, 2 skipped
- [x] `pytest unittests/` — 533 passed, 79 skipped (full suite, no regressions)
- [x] `tox -e linting` — pylint 10.00/10
- [x] `tox -e type_check` — mypy --strict clean (29 source files + 4 examples)
- [x] `tox -e spell_check` — codespell clean
- [x] `black --check` / `isort --check` clean
- [x] Independent reviewer pass on `git diff origin/main...HEAD` — approved with minor nits (all applied)
- [ ] Manual verification on a real SAP GUI with a dual-mandant shared-`connection_name` config — the working hypothesis about COM dedup has **not** been directly confirmed and a downstream local test could not reproduce the symptom in one same-user configuration. Both fixes here are framed as defensive hardening regardless of whether the COM-dedup hypothesis holds; the post-login verification is strictly an improvement even if the close-first path turns out to be irrelevant for a given consumer's bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)