### PR TITLE
fix(login): do not auto-close existing connections (revert 0.5.0 regression)

### DIFF
--- a/src/sapsucker/login.py
+++ b/src/sapsucker/login.py
@@ -73,10 +73,20 @@ def login(
     saplogon_exe_path: str | None = None,
     timeout: int = 30,
 ) -> GuiSession:
-    """Connect to SAP GUI, open a connection, fill the login screen, return a session.
+    """Connect to SAP GUI, open a NEW connection, fill the login screen, return a session.
 
     Launches SAP Logon if not already running. Handles the "multiple logon" popup
     by selecting "continue without ending other sessions" (OPT2).
+
+    Each call to ``login()`` opens a fresh ``con[N]`` via
+    ``app.open_connection`` and **does not affect any existing connection
+    that already shares the same ``connection_name``**. This makes it
+    legal to be logged into the same SAP Logon entry as multiple
+    distinct ``(client, user)`` tuples concurrently — for example one
+    background sub-agent in client 100 and another in client 210, both
+    via "HF S/4". If you instead want serial-switching semantics
+    (close any prior matching connection first), call
+    :func:`close_connections_named` explicitly before ``login()``.
 
     Args:
         connection_name: SAP Logon entry name (e.g. "HF S/4").
@@ -108,16 +118,15 @@ def login(
     except SapConnectionError:
         app = SapGui.launch(exe_path=saplogon_exe_path or discover_saplogon_path(), timeout=timeout)
 
-    # Step 2a: Close any pre-existing connection sharing this description.
-    # ``OpenConnection(description)`` in SAP GUI Scripting returns an
-    # already-open connection by description rather than creating a fresh
-    # one; that would leave us with the prior session (wrong client/user)
-    # and the ``program == SAPMSYST`` guard below would skip the credential
-    # fill block entirely, silently misrouting the caller. Closing matches
-    # up-front forces a fresh SAPMSYST login dynpro — see issue #24.
-    close_connections_named(app, connection_name)
-
-    # Step 2b: Open connection
+    # Step 2: Open a new connection. ``app.open_connection(description)``
+    # adds a new ``con[N]`` to the COM tree without affecting any existing
+    # connection that shares the same description — multiple parallel
+    # connections to the same SAP Logon entry (e.g. one per mandant or
+    # one per user) are a supported topology and the caller may rely on it.
+    # If you genuinely want serial-switching semantics (close any prior
+    # connection of the same name first), call :func:`close_connections_named`
+    # explicitly before ``login()`` — see issue #24 history for the
+    # rationale behind keeping that behaviour opt-in.
     conn = app.open_connection(connection_name, sync=True)
     session = wait_for_session(conn, timeout=timeout)
 
@@ -149,14 +158,12 @@ def login(
     if sbar is not None and cast(Any, sbar).message_type == "E":
         raise SapConnectionError(f"Login failed: {cast(Any, sbar).text}")
 
-    # Step 7: Verify we actually landed where we asked to. The Step 2a
-    # close-existing path handles the shared-``connection_name`` COM
-    # dedup case, but other routes to a wrong-client session exist —
-    # notably SSO/SNC or a cached logon ticket that auto-authenticates
-    # before we reach the SAPMSYST dynpro, causing the credential-fill
-    # block to be skipped entirely. In any such case we'd rather raise
-    # loudly here than hand back a session silently logged in as the
-    # wrong user or in the wrong client — see issue #24.
+    # Step 7: Verify we actually landed where we asked to. If the
+    # SAPMSYST credential-fill block was skipped (e.g. because SSO/SNC
+    # or a cached logon ticket auto-authenticated before we reached the
+    # login dynpro, or because some other path bypassed it) we'd rather
+    # raise loudly here than hand back a session silently logged in as
+    # the wrong user or in the wrong client — see issue #24.
     actual_client = str(session.info.client)
     if actual_client != client:
         raise SapConnectionError(
@@ -201,14 +208,19 @@ def logoff(session: GuiSession) -> None:
 def close_connections_named(app: Any, description: str) -> int:
     """Close every open connection whose ``Description`` matches *description*.
 
-    Used by :func:`login` to force ``OpenConnection`` to create a fresh
-    connection rather than return an already-open one by name — see
-    issue #24. Safe to call directly from consumer code that needs the
-    same behaviour (e.g. to pre-clean before opening a second mandant
-    on the same SAP Logon entry).
+    Opt-in helper for consumers that want **serial-switching** semantics
+    on a SAP Logon entry: call this *before* :func:`login` to drop any
+    prior connection of the same name so the upcoming ``login()`` is the
+    only one. ``login()`` itself does **not** call this — it opens a new
+    parallel connection without affecting existing ones, because the
+    parallel-multi-mandant topology (one SAP Logon entry, multiple
+    concurrent ``(client, user)`` logins) is a supported and common
+    arrangement we don't want to break by default. See issue #24 for
+    history.
 
     Returns the number of connections actually closed. If SAP GUI is
-    not running, returns 0 without raising.
+    not running (or ``app.com.Children`` is not accessible for any other
+    reason), returns 0 without raising.
 
     Uses reverse iteration over ``app.com.Children`` because the COM
     ``GuiConnectionCollection`` mutates on close — the same reverse

--- a/src/sapsucker/login.py
+++ b/src/sapsucker/login.py
@@ -88,6 +88,13 @@ def login(
     (close any prior matching connection first), call
     :func:`close_connections_named` explicitly before ``login()``.
 
+    .. note::
+       sapsucker 0.5.0 briefly called ``close_connections_named``
+       implicitly here, which broke the parallel-multi-mandant topology
+       described above. That was reverted in 0.5.1. If you upgraded
+       from 0.5.0 expecting ``login()`` to clean up after itself, you
+       now need to call :func:`close_connections_named` yourself.
+
     Args:
         connection_name: SAP Logon entry name (e.g. "HF S/4").
         client: SAP client/mandant (e.g. "100").
@@ -217,6 +224,13 @@ def close_connections_named(app: Any, description: str) -> int:
     concurrent ``(client, user)`` logins) is a supported and common
     arrangement we don't want to break by default. See issue #24 for
     history.
+
+    .. note::
+       sapsucker 0.5.0 briefly had ``login()`` call this helper
+       implicitly. That was reverted in 0.5.1 because it broke parallel
+       multi-mandant logins. The helper is still public so consumers
+       that genuinely want the old serial-switching behaviour can
+       opt in with one extra line.
 
     Returns the number of connections actually closed. If SAP GUI is
     not running (or ``app.com.Children`` is not accessible for any other

--- a/unittests/test_login.py
+++ b/unittests/test_login.py
@@ -270,14 +270,12 @@ class TestLoginVerifiesClientAndUser:
     """
 
     @patch("sapsucker.login.wait_for_session")
-    @patch("sapsucker.login.close_connections_named")
     @patch("sapsucker.SapGui")
     @patch("sapsucker.login.time")
-    def test_client_match_succeeds(self, mock_time, mock_sap_gui_cls, mock_close, mock_wait):
+    def test_client_match_succeeds(self, mock_time, mock_sap_gui_cls, mock_wait):
         """Happy path: actual client matches requested → session returned."""
         session = _make_mock_session(program="SAPLSMTR_NAVIGATION", client="210", user="MUSTERFRAUM")
         mock_wait.return_value = session
-        mock_close.return_value = 0
 
         result = login(
             connection_name="HF S/4",
@@ -289,14 +287,12 @@ class TestLoginVerifiesClientAndUser:
         assert result is session
 
     @patch("sapsucker.login.wait_for_session")
-    @patch("sapsucker.login.close_connections_named")
     @patch("sapsucker.SapGui")
     @patch("sapsucker.login.time")
-    def test_client_mismatch_raises(self, mock_time, mock_sap_gui_cls, mock_close, mock_wait):
+    def test_client_mismatch_raises(self, mock_time, mock_sap_gui_cls, mock_wait):
         """If the new session lands in the wrong client, raise SapConnectionError."""
         session = _make_mock_session(program="SAPLSMTR_NAVIGATION", client="100", user="MUSTERFRAUM")
         mock_wait.return_value = session
-        mock_close.return_value = 0
 
         with pytest.raises(SapConnectionError, match="Login landed in client '100' but '210' was requested"):
             login(
@@ -307,14 +303,12 @@ class TestLoginVerifiesClientAndUser:
             )
 
     @patch("sapsucker.login.wait_for_session")
-    @patch("sapsucker.login.close_connections_named")
     @patch("sapsucker.SapGui")
     @patch("sapsucker.login.time")
-    def test_user_mismatch_raises(self, mock_time, mock_sap_gui_cls, mock_close, mock_wait):
+    def test_user_mismatch_raises(self, mock_time, mock_sap_gui_cls, mock_wait):
         """If the new session lands as the wrong user, raise SapConnectionError."""
         session = _make_mock_session(program="SAPLSMTR_NAVIGATION", client="100", user="MUSTERMANNM")
         mock_wait.return_value = session
-        mock_close.return_value = 0
 
         with pytest.raises(
             SapConnectionError, match="Login landed as user 'MUSTERMANNM' but 'MUSTERFRAUM' was requested"
@@ -327,14 +321,12 @@ class TestLoginVerifiesClientAndUser:
             )
 
     @patch("sapsucker.login.wait_for_session")
-    @patch("sapsucker.login.close_connections_named")
     @patch("sapsucker.SapGui")
     @patch("sapsucker.login.time")
-    def test_user_comparison_is_case_insensitive(self, mock_time, mock_sap_gui_cls, mock_close, mock_wait):
+    def test_user_comparison_is_case_insensitive(self, mock_time, mock_sap_gui_cls, mock_wait):
         """SAP is case-insensitive about usernames — 'mustermannm' matches 'MUSTERMANNM'."""
         session = _make_mock_session(program="SAPLSMTR_NAVIGATION", client="100", user="MUSTERMANNM")
         mock_wait.return_value = session
-        mock_close.return_value = 0
 
         # Lower-case request should succeed against upper-case server response
         result = login(

--- a/unittests/test_login.py
+++ b/unittests/test_login.py
@@ -209,29 +209,28 @@ class TestLogin:
         mock_sap_gui_cls.launch.assert_called_once()
 
 
-class TestLoginClosesExistingConnections:
-    """Regression coverage for issue #24.
+class TestLoginDoesNotCloseExistingConnections:
+    """Regression guard for the parallel-multi-mandant topology.
 
-    ``login()`` must close any pre-existing connection sharing the
-    requested description BEFORE calling ``app.open_connection``,
-    otherwise ``OpenConnection`` returns the existing connection by
-    description and the credential-fill block is skipped — the caller
-    ends up silently routed to the prior session's client/user.
+    sapsucker 0.5.0 made ``login()`` implicitly call
+    :func:`close_connections_named` before opening a new connection.
+    That broke the legitimate use case of being logged into one SAP
+    Logon entry as multiple distinct ``(client, user)`` tuples
+    concurrently — calling ``login()`` for the second tuple would have
+    closed the first. 0.5.1 reverted that. These tests pin down the
+    revert: ``login()`` must NOT touch any existing connection.
+    Consumers that genuinely want serial-switching are expected to call
+    ``close_connections_named()`` themselves before ``login()``.
     """
 
     @patch("sapsucker.login.wait_for_session")
     @patch("sapsucker.login.close_connections_named")
     @patch("sapsucker.SapGui")
     @patch("sapsucker.login.time")
-    def test_close_runs_before_open_connection(self, mock_time, mock_sap_gui_cls, mock_close, mock_wait):
-        """close_connections_named must be called before app.open_connection."""
+    def test_login_does_not_call_close_connections_named(self, mock_time, mock_sap_gui_cls, mock_close, mock_wait):
+        """login() must NOT auto-close existing connections — that would kill parallel logins."""
         session = _make_mock_session(program="SAPLSMTR_NAVIGATION", client="100", user="TESTUSER")
         mock_wait.return_value = session
-        app = mock_sap_gui_cls.connect.return_value
-        call_order: list[str] = []
-
-        mock_close.side_effect = lambda _app, _desc: call_order.append("close") or 0
-        app.open_connection.side_effect = lambda *a, **kw: call_order.append("open") or MagicMock()
 
         login(
             connection_name="HF S/4",
@@ -240,43 +239,17 @@ class TestLoginClosesExistingConnections:
             password="secret",
         )
 
-        assert call_order == ["close", "open"]
-        mock_close.assert_called_once_with(app, "HF S/4")
+        mock_close.assert_not_called()
 
     @patch("sapsucker.login.wait_for_session")
     @patch("sapsucker.login.close_connections_named")
     @patch("sapsucker.SapGui")
     @patch("sapsucker.login.time")
-    def test_close_returning_zero_is_fine(self, mock_time, mock_sap_gui_cls, mock_close, mock_wait):
-        """login() still proceeds normally when there are no matches to close."""
-        session = _make_mock_session(program="SAPLSMTR_NAVIGATION", client="100", user="TESTUSER")
-        mock_wait.return_value = session
-        mock_close.return_value = 0
-
-        result = login(
-            connection_name="FRESH",
-            client="100",
-            user="TESTUSER",
-            password="secret",
-        )
-
-        assert result is session
-
-    @patch("sapsucker.login.wait_for_session")
-    @patch("sapsucker.login.close_connections_named")
-    @patch("sapsucker.SapGui")
-    @patch("sapsucker.login.time")
-    def test_close_is_called_after_launch_path(self, mock_time, mock_sap_gui_cls, mock_close, mock_wait):
-        """close_connections_named also runs on the SAP-GUI-not-running launch path.
-
-        If SAP GUI was freshly launched there's nothing to close (returns 0),
-        but the *call* must still happen on the ``launch()``-returned app so
-        a subsequent reconnection attempt by the same consumer is consistent.
-        """
+    def test_login_does_not_call_close_on_launch_path_either(self, mock_time, mock_sap_gui_cls, mock_close, mock_wait):
+        """Same guard for the SAP-GUI-not-running cold-start path."""
         mock_sap_gui_cls.connect.side_effect = SapConnectionError("Not running")
         session = _make_mock_session(program="SAPLSMTR_NAVIGATION", client="100", user="TESTUSER")
         mock_wait.return_value = session
-        mock_close.return_value = 0
 
         login(
             connection_name="HF S/4",
@@ -285,11 +258,7 @@ class TestLoginClosesExistingConnections:
             password="secret",
         )
 
-        mock_close.assert_called_once()
-        # Called with the launched app, not the (failed) connect app
-        args, _ = mock_close.call_args
-        assert args[0] is mock_sap_gui_cls.launch.return_value
-        assert args[1] == "HF S/4"
+        mock_close.assert_not_called()
 
 
 class TestLoginVerifiesClientAndUser:


### PR DESCRIPTION
Refs #24. Releases as **0.5.1**.

## What this reverts

sapsucker 0.5.0 (PR #26) made `login()` implicitly call `close_connections_named(app, connection_name)` before `app.open_connection`. The intent was defensive against an unconfirmed hypothesis about `OpenConnection` deduping by description. **The actual effect was to break a legitimate use case:** being logged into one SAP Logon entry as multiple distinct `(client, user, password)` tuples concurrently — for example one background sub-agent in client 100 as MUSTERMANNM and another in client 210 as MUSTERFRAUM, both via "HF S/4". With 0.5.0, calling `login()` for the second tuple would silently close the first.

That topology is supported, common, and the natural way to model "different mandants/users on the same SAP system without duplicating SAP Logon entries." Dropping it by default was the wrong call.

This PR removes the implicit close from `login()`. Consumers that genuinely want serial-switching can still call `close_connections_named()` themselves before `login()` — the helper stays public.

## Honest framing — what we don't know

The original `#24` root cause is **still unconfirmed**:
- The hypothesis was: "`app.OpenConnection(description)` reuses an already-open connection by description, causing the credential-fill block in `login()` to be skipped." That was **never directly verified** at the COM layer.
- The downstream symptom in `Hochfrequenz/sapwebgui.mcp#659` (Tom reporting wrong-Mandant routing when switching `system_key`) was **never reproduced** in a local manual test against a real SAP system in a structurally similar config.

So 0.5.1 **no longer attempts to defend against the COM-dedup hypothesis**. We're betting that:
1. The hypothesis was wrong (`OpenConnection` does NOT actually dedupe — it opens a new connection as the original module docstring claims), OR
2. The hypothesis was correct but only triggers in specific configurations we still don't understand.

In **either** case, the post-login `session.info.client` / `session.info.user` verification (Step 7 of `login()`) catches any wrong-Mandant landing as a loud `SapConnectionError` instead of silent misrouting. That half stays. It's the only part of #26 that was strictly correct regardless of whether the COM-dedup hypothesis holds.

**Bottom line:** we're trading a speculative fix that broke a real use case for a confirmed regression revert plus a loud safety net. If Tom's bug recurs, we'll see it as a `SapConnectionError` with `actual_client` vs `requested_client` data — that data is what we actually need to find the real root cause, and the close-first was preventing us from getting it.

## What stays

- **`close_connections_named` remains a public helper** in `__all__`. Consumers wanting serial-switching opt in with one extra line.
- **Post-login client/user verification** stays. Strictly defensive, never breaks any topology, only surfaces silent wrong-Mandant landings as loud errors.
- **The `client` and `user` mismatch error messages** remain unchanged (`"Login landed in client 'X' but 'Y' was requested..."` and `"Login landed as user 'X' but 'Y' was requested..."`).

## Code changes

`src/sapsucker/login.py`:
- Removes the implicit `close_connections_named(app, connection_name)` call from `login()` (the old "Step 2a" block).
- Renumbers the surrounding comment from "Step 2a / Step 2b" back to a single "Step 2: Open a new connection" block, with explicit prose about the parallel-multi-mandant topology and a pointer to the opt-in helper.
- Adds a `.. note::` to `login()`'s docstring documenting the 0.5.0 → 0.5.1 behaviour change for upgrading consumers.
- Adds a matching `.. note::` to `close_connections_named()`'s docstring.
- Updates the Step 7 comment to drop the now-stale "Step 2a" reference; keeps SSO/SNC/cached-ticket as the rationale for why post-login verification is still worth doing.

`unittests/test_login.py`:
- Removes `TestLoginClosesExistingConnections` (3 tests asserting the old close-before-open wiring).
- Adds `TestLoginDoesNotCloseExistingConnections` (2 regression tests asserting `login()` does NOT call `close_connections_named` — neither on the connect happy path nor on the launch cold-start path).
- Drops the now-dead `@patch("sapsucker.login.close_connections_named")` decorators from `TestLoginVerifiesClientAndUser` since `login()` no longer calls the helper. Tests still cover the same behaviour.
- Keeps `TestCloseConnectionsNamed` (5 direct unit tests on the helper) and `TestCloseConnectionsNamedPublicAPI` (1 export guard) unchanged.

Net: 26 tests pass, 2 skipped (Windows-only winreg tests).

## Checklist

- [x] `pytest unittests/test_login.py` — 26 passed, 2 skipped
- [x] `pytest unittests/` — 533 passed, 79 skipped (full suite, no regressions)
- [x] `tox -e linting` — pylint 10.00/10
- [x] `tox -e type_check` — mypy --strict clean
- [x] `tox -e spell_check` — codespell clean
- [x] `black --check` clean
- [x] Independent reviewer pass with **the corrected understanding** of the parallel-multi-mandant topology — approved with two small doc/test nits, both applied in d78c025

## Downstream

`Hochfrequenz/sapwebgui.mcp` is currently pinned to `sapsucker==0.4.1` in production (v0.9.14) and has its own copy of the same close-first workaround in `DesktopBackend.login`. Once this PR ships as sapsucker 0.5.1, sapwebgui.mcp will get a separate cleanup PR that bumps the pin and drops its consumer-side workaround in the same direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)