### PR TITLE
fix(deps): make pywin32 an unconditional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Testing",
 ]
 dependencies = [
-    "pywin32>=306; sys_platform == 'win32'",
+    "pywin32>=306",
     "pydantic>=2.0",
 ]
 dynamic = ["readme", "version"]


### PR DESCRIPTION
## Summary
- Remove the `sys_platform == 'win32'` environment marker from the `pywin32` dependency
- sapsucker only works on Windows, so allowing silent installation on other platforms is misleading — this makes the failure explicit at install time

## Test plan
- [ ] Verify `pyproject.toml` parses correctly (`pip install -e .` on Windows)
- [ ] Confirm installing on a non-Windows platform now correctly fails due to pywin32

🤖 Generated with [Claude Code](https://claude.com/claude-code)