### PR TITLE
fix(table): wrap get_cell() return value via factory dispatch

### DIFF
--- a/src/sapsucker/_factory.py
+++ b/src/sapsucker/_factory.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sapsucker._wrap import _set_dispatch_tables, wrap_com_object  # noqa: F401 - re-export
+from sapsucker._wrap import _set_dispatch_tables, wrap_com_object  # noqa: F401  # pylint: disable=unused-import
 from sapsucker.components.application import GuiApplication
 from sapsucker.components.base import GuiComponent
 from sapsucker.components.button import GuiButton

--- a/src/sapsucker/_factory.py
+++ b/src/sapsucker/_factory.py
@@ -1,10 +1,8 @@
-"""Two-level type dispatch factory for wrapping raw COM objects."""
+"""Two-level type dispatch factory for SAP GUI COM components."""
 
 from __future__ import annotations
 
-import logging
-from typing import Any
-
+from sapsucker._wrap import _set_dispatch_tables, wrap_com_object  # noqa: F401 - re-export
 from sapsucker.components.application import GuiApplication
 from sapsucker.components.base import GuiComponent
 from sapsucker.components.button import GuiButton
@@ -55,8 +53,6 @@ from sapsucker.components.window import (
     GuiMessageWindow,
     GuiModalWindow,
 )
-
-logger = logging.getLogger(__name__)
 
 # Level 1: TypeAsNumber -> Python class
 _TYPE_MAP: dict[int, type[GuiComponent]] = {
@@ -117,23 +113,4 @@ _SHELL_SUBTYPE_MAP: dict[str, type[GuiShell]] = {
 }
 
 
-def wrap_com_object(com_obj: Any) -> GuiComponent:
-    """Wrap a raw COM dispatch object in the appropriate Python class.
-
-    Uses two-level dispatch:
-    1. TypeAsNumber selects the base class.
-    2. For GuiShell (type 122), SubType refines to the concrete shell class.
-    3. Unknown types fall back to GuiComponent.
-    """
-    type_num = com_obj.TypeAsNumber
-    cls = _TYPE_MAP.get(type_num)
-    if cls is GuiShell:
-        sub_type = getattr(com_obj, "SubType", "")
-        cls = _SHELL_SUBTYPE_MAP.get(sub_type, GuiShell)
-    elif cls is None:
-        cls = GuiComponent
-        logger.debug(
-            "unknown_type_fallback",
-            extra={"type_as_number": type_num, "com_type": getattr(com_obj, "Type", "?")},
-        )
-    return cls(com_obj)
+_set_dispatch_tables(_TYPE_MAP, _SHELL_SUBTYPE_MAP, 122, GuiComponent)

--- a/src/sapsucker/_wrap.py
+++ b/src/sapsucker/_wrap.py
@@ -1,0 +1,61 @@
+"""COM object dispatch — importable by all component modules without circularity.
+
+wrap_com_object lives here, not in _factory.py, so that component modules can
+import it at module level without creating a circular dependency.
+
+_factory.py populates the dispatch tables by calling _set_dispatch_tables() at
+the end of its own module body.  sapsucker/components/__init__.py imports
+_factory at its bottom, which guarantees registration happens before any
+component method can call wrap_com_object.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from sapsucker.components.base import GuiComponent
+
+logger = logging.getLogger(__name__)
+
+_type_map: dict[int, type] = {}
+_shell_subtype_map: dict[str, type] = {}
+_shell_type_num: int = 122
+_fallback_cls: type | None = None
+
+
+def _set_dispatch_tables(
+    type_map: dict[int, type],
+    shell_subtype_map: dict[str, type],
+    shell_type_num: int,
+    fallback_cls: type,
+) -> None:
+    """Called once by _factory.py after all component classes are defined."""
+    global _type_map, _shell_subtype_map, _shell_type_num, _fallback_cls
+    _type_map = type_map
+    _shell_subtype_map = shell_subtype_map
+    _shell_type_num = shell_type_num
+    _fallback_cls = fallback_cls
+
+
+def wrap_com_object(com_obj: Any) -> GuiComponent:
+    """Wrap a raw COM dispatch object in the appropriate Python class.
+
+    Uses two-level dispatch:
+    1. TypeAsNumber selects the base class.
+    2. For GuiShell (type 122), SubType refines to the concrete shell class.
+    3. Unknown types fall back to GuiComponent.
+    """
+    type_num = com_obj.TypeAsNumber
+    cls = _type_map.get(type_num)
+    if cls is not None and type_num == _shell_type_num:
+        sub_type = getattr(com_obj, "SubType", "")
+        cls = _shell_subtype_map.get(sub_type, cls)
+    elif cls is None:
+        cls = _fallback_cls
+        logger.debug(
+            "unknown_type_fallback",
+            extra={"type_as_number": type_num, "com_type": getattr(com_obj, "Type", "?")},
+        )
+    return cls(com_obj)  # type: ignore[misc]

--- a/src/sapsucker/_wrap.py
+++ b/src/sapsucker/_wrap.py
@@ -21,8 +21,8 @@ logger = logging.getLogger(__name__)
 
 _type_map: dict[int, type] = {}
 _shell_subtype_map: dict[str, type] = {}
-_shell_type_num: int = 122
-_fallback_cls: type | None = None
+_SHELL_TYPE_NUM: int = 122
+_FALLBACK_CLS: type | None = None
 
 
 def _set_dispatch_tables(
@@ -32,11 +32,11 @@ def _set_dispatch_tables(
     fallback_cls: type,
 ) -> None:
     """Called once by _factory.py after all component classes are defined."""
-    global _type_map, _shell_subtype_map, _shell_type_num, _fallback_cls
+    global _type_map, _shell_subtype_map, _SHELL_TYPE_NUM, _FALLBACK_CLS  # pylint: disable=global-statement
     _type_map = type_map
     _shell_subtype_map = shell_subtype_map
-    _shell_type_num = shell_type_num
-    _fallback_cls = fallback_cls
+    _SHELL_TYPE_NUM = shell_type_num
+    _FALLBACK_CLS = fallback_cls
 
 
 def wrap_com_object(com_obj: Any) -> GuiComponent:
@@ -49,13 +49,13 @@ def wrap_com_object(com_obj: Any) -> GuiComponent:
     """
     type_num = com_obj.TypeAsNumber
     cls = _type_map.get(type_num)
-    if cls is not None and type_num == _shell_type_num:
+    if cls is not None and type_num == _SHELL_TYPE_NUM:
         sub_type = getattr(com_obj, "SubType", "")
         cls = _shell_subtype_map.get(sub_type, cls)
     elif cls is None:
-        cls = _fallback_cls
+        cls = _FALLBACK_CLS
         logger.debug(
             "unknown_type_fallback",
             extra={"type_as_number": type_num, "com_type": getattr(com_obj, "Type", "?")},
         )
-    return cls(com_obj)  # type: ignore[misc]
+    return cls(com_obj)  # type: ignore[misc, no-any-return]

--- a/src/sapsucker/components/__init__.py
+++ b/src/sapsucker/components/__init__.py
@@ -46,7 +46,7 @@ from sapsucker.components.window import GuiFrameWindow, GuiMainWindow, GuiMessag
 # _set_dispatch_tables, which populates wrap_com_object's dispatch maps.  Any path
 # that imports a component class goes through this __init__, so the maps are always
 # populated before wrap_com_object can be called.
-import sapsucker._factory as _factory  # noqa: F401
+from sapsucker import _factory  # noqa: F401  # isort: skip
 
 __all__ = [
     # base

--- a/src/sapsucker/components/__init__.py
+++ b/src/sapsucker/components/__init__.py
@@ -42,6 +42,12 @@ from sapsucker.components.toolbar import GuiContextMenu, GuiMenu, GuiMenubar, Gu
 from sapsucker.components.tree import GuiTree
 from sapsucker.components.window import GuiFrameWindow, GuiMainWindow, GuiMessageWindow, GuiModalWindow
 
+# Importing _factory here (after all component classes are defined above) triggers
+# _set_dispatch_tables, which populates wrap_com_object's dispatch maps.  Any path
+# that imports a component class goes through this __init__, so the maps are always
+# populated before wrap_com_object can be called.
+import sapsucker._factory as _factory  # noqa: F401
+
 __all__ = [
     # base
     "GuiComponent",

--- a/src/sapsucker/components/application.py
+++ b/src/sapsucker/components/application.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from sapsucker._wrap import wrap_com_object
 from sapsucker.components.base import GuiContainer
 
 if TYPE_CHECKING:
@@ -33,8 +34,6 @@ class GuiApplication(GuiContainer):
     @property
     def active_session(self) -> GuiSession:
         """Return the currently active session."""
-        from sapsucker._factory import wrap_com_object
-
         return wrap_com_object(self._com.ActiveSession)  # type: ignore[return-value]
 
     @property
@@ -77,7 +76,6 @@ class GuiApplication(GuiContainer):
                 connection name is not found in SAP Logon.
         """
         from sapsucker._errors import SapConnectionError
-        from sapsucker._factory import wrap_com_object
 
         try:
             com_conn = self._com.OpenConnection(description, sync, raise_error)
@@ -101,8 +99,6 @@ class GuiApplication(GuiContainer):
         self, conn_string: str, sync: bool = True, raise_error: bool = True
     ) -> GuiConnection:
         """Open a connection using a raw connection string."""
-        from sapsucker._factory import wrap_com_object
-
         com_conn = self._com.OpenConnectionByConnectionString(conn_string, sync, raise_error)
         return wrap_com_object(com_conn)  # type: ignore[return-value]
 

--- a/src/sapsucker/components/base.py
+++ b/src/sapsucker/components/base.py
@@ -1,6 +1,6 @@
 """Base classes for the SAP GUI component hierarchy."""
 
-# pylint: disable=import-outside-toplevel,broad-exception-caught
+# pylint: disable=broad-exception-caught
 
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from sapsucker._errors import ElementNotFoundError
+from sapsucker._wrap import wrap_com_object
 
 if TYPE_CHECKING:
     from sapsucker.components.collection import GuiComponentCollection
@@ -185,8 +186,6 @@ class GuiContainer(GuiComponent):
         Returns:
             The wrapped component, or None if not found and raise_error is False.
         """
-        from sapsucker._factory import wrap_com_object
-
         result = self._com.FindById(id, False)
         if result is None:
             logger.debug("element_not_found", extra={"id": id, "parent": self.id})
@@ -650,15 +649,11 @@ class GuiVContainer(GuiContainer, GuiVComponent):
 
     def find_by_name(self, name: str, type_name: str) -> GuiComponent | None:
         """Find the first child element matching name and type string. Returns None if not found."""
-        from sapsucker._factory import wrap_com_object
-
         result = self._com.FindByName(name, type_name)
         return wrap_com_object(result) if result is not None else None
 
     def find_by_name_ex(self, name: str, type_number: int) -> GuiComponent | None:
         """Find the first child element matching name and type number. Returns None if not found."""
-        from sapsucker._factory import wrap_com_object
-
         result = self._com.FindByNameEx(name, type_number)
         return wrap_com_object(result) if result is not None else None
 

--- a/src/sapsucker/components/base.py
+++ b/src/sapsucker/components/base.py
@@ -1,6 +1,6 @@
 """Base classes for the SAP GUI component hierarchy."""
 
-# pylint: disable=broad-exception-caught
+# pylint: disable=broad-exception-caught,import-outside-toplevel
 
 from __future__ import annotations
 

--- a/src/sapsucker/components/collection.py
+++ b/src/sapsucker/components/collection.py
@@ -1,11 +1,10 @@
 """Collection wrappers for SAP GUI COM collections."""
 
-# pylint: disable=import-outside-toplevel
-
 from __future__ import annotations
 
 from typing import Any, Iterator
 
+from sapsucker._wrap import wrap_com_object
 from sapsucker.components.base import GuiComponent
 
 __all__ = ["GuiCollection", "GuiComponentCollection"]
@@ -23,8 +22,6 @@ class GuiComponentCollection:
 
     def __getitem__(self, index: int) -> GuiComponent:
         """Return the wrapped component at the given index."""
-        from sapsucker._factory import wrap_com_object
-
         length = self._com.Count
         if index < 0:
             index += length

--- a/src/sapsucker/components/session.py
+++ b/src/sapsucker/components/session.py
@@ -1,11 +1,10 @@
 """GuiSession and GuiSessionInfo — session-level wrappers."""
 
-# pylint: disable=import-outside-toplevel
-
 from __future__ import annotations
 
 from typing import Any
 
+from sapsucker._wrap import wrap_com_object
 from sapsucker.components.base import GuiComponent, GuiContainer
 
 __all__ = ["GuiSession", "GuiSessionInfo"]
@@ -145,8 +144,6 @@ class GuiSession(GuiContainer):
     @property
     def active_window(self) -> GuiComponent:
         """Return the active window wrapped in the correct Python class."""
-        from sapsucker._factory import wrap_com_object
-
         return wrap_com_object(self._com.ActiveWindow)
 
     def create_session(self) -> None:

--- a/src/sapsucker/components/table.py
+++ b/src/sapsucker/components/table.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from sapsucker._wrap import wrap_com_object
 from sapsucker.components.base import GuiComponent, GuiVContainer
 
 __all__ = ["GuiTableColumn", "GuiTableControl", "GuiTableRow"]
@@ -53,9 +54,9 @@ class GuiTableControl(GuiVContainer):
         """Return the COM rows collection."""
         return self._com.Rows
 
-    def get_cell(self, row: int, col: int) -> Any:
-        """Return the COM object for the cell at (row, col)."""
-        return self._com.GetCell(row, col)
+    def get_cell(self, row: int, col: int) -> GuiComponent:
+        """Return the wrapped component for the cell at (row, col)."""
+        return wrap_com_object(self._com.GetCell(row, col))
 
     def get_absolute_row(self, row: int) -> "GuiTableRow":
         """Return a row by absolute index (works with scrolled tables).

--- a/src/sapsucker/components/window.py
+++ b/src/sapsucker/components/window.py
@@ -1,9 +1,8 @@
 """Window components — GuiFrameWindow, GuiMainWindow, GuiModalWindow, GuiMessageWindow."""
 
-# pylint: disable=import-outside-toplevel
-
 from __future__ import annotations
 
+from sapsucker._wrap import wrap_com_object
 from sapsucker.components.base import GuiVComponent, GuiVContainer
 
 __all__ = ["GuiFrameWindow", "GuiMainWindow", "GuiMessageWindow", "GuiModalWindow"]
@@ -28,15 +27,11 @@ class GuiFrameWindow(GuiVContainer):
     @property
     def gui_focus(self) -> GuiVComponent:
         """Return the element that currently has GUI focus."""
-        from sapsucker._factory import wrap_com_object
-
         return wrap_com_object(self._com.GuiFocus)  # type: ignore[return-value]
 
     @property
     def system_focus(self) -> GuiVComponent:
         """Return the element that currently has system focus."""
-        from sapsucker._factory import wrap_com_object
-
         return wrap_com_object(self._com.SystemFocus)  # type: ignore[return-value]
 
     @property

--- a/unittests/test_se37_integration.py
+++ b/unittests/test_se37_integration.py
@@ -9,6 +9,7 @@ import time
 
 import pytest
 
+from sapsucker.components.base import GuiComponent
 from unittests.conftest import is_sap_integration_test_machine
 
 pytestmark = [
@@ -173,15 +174,15 @@ class TestGuiTableControl:
         rows = table.rows
         assert rows is not None
 
-    def test_table_get_cell(self, se37_session):
-        """Verify get_cell returns a COM object for row 0, col 0."""
+    def test_table_get_cell_returns_wrapped_component(self, se37_session):
+        """get_cell returns a wrapped GuiComponent, not a raw COM object."""
         table = _find_table_in_tab(se37_session, _TAB_IMPORT_ID)
         if table is None:
             pytest.skip("No table control found in Import tab")
         if table.row_count == 0 or table.columns.Count == 0:
             pytest.skip("Import table has no data")
         cell = table.get_cell(0, 0)
-        assert cell is not None
+        assert isinstance(cell, GuiComponent)
 
     def test_table_in_export_tab(self, se37_session):
         """The Export tab also contains a table control."""

--- a/unittests/test_table.py
+++ b/unittests/test_table.py
@@ -1,7 +1,8 @@
 """Tests for GuiTableControl, GuiTableRow, GuiTableColumn — issues #476, #517."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from sapsucker.components.base import GuiComponent
 from sapsucker.components.table import (
     GuiTableColumn,
     GuiTableControl,
@@ -68,13 +69,25 @@ class TestGuiTableControl:
         tbl._com.Rows.Count = 5
         assert tbl.rows.Count == 5
 
-    def test_get_cell(self):
+    def test_get_cell_calls_wrap(self):
         tbl = _make_table()
         cell_com = MagicMock()
         tbl._com.GetCell.return_value = cell_com
-        result = tbl.get_cell(0, 1)
+        wrapped = MagicMock(spec=GuiComponent)
+        with patch("sapsucker.components.table.wrap_com_object", return_value=wrapped) as mock_wrap:
+            result = tbl.get_cell(0, 1)
         tbl._com.GetCell.assert_called_once_with(0, 1)
-        assert result is cell_com
+        mock_wrap.assert_called_once_with(cell_com)
+        assert result is wrapped
+
+    def test_get_cell_returns_gui_component(self):
+        """get_cell returns a GuiComponent, not a raw COM object."""
+        from unittests.conftest import make_mock_com
+        tbl = _make_table()
+        cell_com = make_mock_com(type_as_number=31)  # GuiTextField
+        tbl._com.GetCell.return_value = cell_com
+        result = tbl.get_cell(0, 0)
+        assert isinstance(result, GuiComponent)
 
     def test_get_absolute_row(self):
         tbl = _make_table()

--- a/unittests/test_table.py
+++ b/unittests/test_table.py
@@ -83,6 +83,7 @@ class TestGuiTableControl:
     def test_get_cell_returns_gui_component(self):
         """get_cell returns a GuiComponent, not a raw COM object."""
         from unittests.conftest import make_mock_com
+
         tbl = _make_table()
         cell_com = make_mock_com(type_as_number=31)  # GuiTextField
         tbl._com.GetCell.return_value = cell_com


### PR DESCRIPTION
## Summary

- `GuiTableControl.get_cell()` was returning a raw COM object (`Any`), inconsistent with every other accessor in sapsucker. It now returns a properly typed `GuiComponent` subclass via the dispatch factory, matching how `find_by_id`, `active_window`, `gui_focus`, etc. all work.
- Broke the circular import that forced all component modules to use local `from sapsucker._factory import wrap_com_object` imports. Extracted `wrap_com_object` into a new `sapsucker._wrap` module; `_factory.py` registers its dispatch tables there at module-init time; `components/__init__.py` imports `_factory` last to trigger registration. Six component files (`base`, `session`, `window`, `collection`, `application`, `table`) now have clean module-level imports.

Closes #43.

## Test plan

- [x] 536 unit tests pass (`PYTHONPATH=src python -m pytest unittests/ --ignore=*integration*`)
- [ ] Integration test `test_table_get_cell_returns_wrapped_component` in `test_se37_integration.py` asserts `isinstance(cell, GuiComponent)` — needs SAP GUI running to execute

Generated with [Claude Code](https://claude.com/claude-code)
