### PR TITLE
fix: explicit re-export of wrap_com_object for mypy --strict compatibility

### DIFF
--- a/src/sapsucker/_factory.py
+++ b/src/sapsucker/_factory.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from sapsucker._wrap import _set_dispatch_tables, wrap_com_object  # noqa: F401  # pylint: disable=unused-import
+from sapsucker._wrap import _set_dispatch_tables
+from sapsucker._wrap import wrap_com_object as wrap_com_object  # noqa: F401  # pylint: disable=unused-import
 from sapsucker.components.application import GuiApplication
 from sapsucker.components.base import GuiComponent
 from sapsucker.components.button import GuiButton

--- a/src/sapsucker/_factory.py
+++ b/src/sapsucker/_factory.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from sapsucker._wrap import _set_dispatch_tables
-from sapsucker._wrap import (  # noqa: F401  # pylint: disable=unused-import,useless-import-alias
-    wrap_com_object as wrap_com_object,
+from sapsucker._wrap import (
+    _set_dispatch_tables,
+    wrap_com_object as wrap_com_object,  # noqa: F401  # pylint: disable=unused-import,useless-import-alias
 )
 from sapsucker.components.application import GuiApplication
 from sapsucker.components.base import GuiComponent

--- a/src/sapsucker/_factory.py
+++ b/src/sapsucker/_factory.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from sapsucker._wrap import _set_dispatch_tables
-from sapsucker._wrap import wrap_com_object as wrap_com_object  # noqa: F401  # pylint: disable=unused-import,useless-import-alias
+from sapsucker._wrap import (  # noqa: F401  # pylint: disable=unused-import,useless-import-alias
+    wrap_com_object as wrap_com_object,
+)
 from sapsucker.components.application import GuiApplication
 from sapsucker.components.base import GuiComponent
 from sapsucker.components.button import GuiButton

--- a/src/sapsucker/_factory.py
+++ b/src/sapsucker/_factory.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from sapsucker._wrap import (
     _set_dispatch_tables,
 )
-from sapsucker._wrap import (  # noqa: F401  # pylint: disable=unused-import,useless-import-alias
-    wrap_com_object as wrap_com_object,
+from sapsucker._wrap import (  
+    wrap_com_object as wrap_com_object,# noqa: F401  # pylint: disable=unused-import,useless-import-alias
 )
 from sapsucker.components.application import GuiApplication
 from sapsucker.components.base import GuiComponent

--- a/src/sapsucker/_factory.py
+++ b/src/sapsucker/_factory.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from sapsucker._wrap import (
     _set_dispatch_tables,
 )
-from sapsucker._wrap import (  
-    wrap_com_object as wrap_com_object,# noqa: F401  # pylint: disable=unused-import,useless-import-alias
+from sapsucker._wrap import (  # noqa: F401  # pylint: disable=unused-import,useless-import-alias
+    wrap_com_object as wrap_com_object,
 )
 from sapsucker.components.application import GuiApplication
 from sapsucker.components.base import GuiComponent

--- a/src/sapsucker/_factory.py
+++ b/src/sapsucker/_factory.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from sapsucker._wrap import (
     _set_dispatch_tables,
-    wrap_com_object as wrap_com_object,  # noqa: F401  # pylint: disable=unused-import,useless-import-alias
+)
+from sapsucker._wrap import (  # noqa: F401  # pylint: disable=unused-import,useless-import-alias
+    wrap_com_object as wrap_com_object,
 )
 from sapsucker.components.application import GuiApplication
 from sapsucker.components.base import GuiComponent

--- a/src/sapsucker/_factory.py
+++ b/src/sapsucker/_factory.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from sapsucker._wrap import _set_dispatch_tables
-from sapsucker._wrap import wrap_com_object as wrap_com_object  # noqa: F401  # pylint: disable=unused-import
+from sapsucker._wrap import wrap_com_object as wrap_com_object  # noqa: F401  # pylint: disable=unused-import,useless-import-alias
 from sapsucker.components.application import GuiApplication
 from sapsucker.components.base import GuiComponent
 from sapsucker.components.button import GuiButton


### PR DESCRIPTION
## Problem

`sapguimcp` (and any downstream project running `mypy --strict`) gets:

```
src/.../desktop/__init__.py:453: error: Module sapsucker._factory does not explicitly export attribute wrap_com_object  [attr-defined]
```

`mypy --strict` enables `no_implicit_reexport`. The previous import form is treated as an implicit re-export and therefore hidden from downstream consumers.

## Fix

Use the `as X` re-export convention that mypy recognises as explicit:

```python
from sapsucker._wrap import _set_dispatch_tables
from sapsucker._wrap import wrap_com_object as wrap_com_object  # noqa: F401  # pylint: disable=unused-import
```

This is the standard mypy pattern for intentional re-exports (PEP 484 / mypy docs).

## Testing

- `pylint _factory.py` 10.00/10
- `mypy _factory.py` no issues