### PR TITLE
fix: work around SAP GUI COM error 618 on collection.Item(index) (mcp#804)

### DIFF
--- a/src/sapsucker/_wrap.py
+++ b/src/sapsucker/_wrap.py
@@ -78,9 +78,9 @@ def com_collection_item(com_collection: Any, index: int) -> Any:
     broad ``except`` swallowed it, so login spun to a 30s timeout with no session.
 
     Strategy, in order (first that succeeds wins):
-      1. ``Item(index)`` — the historical path. Tried first so behaviour is byte
-         -for-byte identical on the (majority of) hosts where it already works;
-         this fix can only *add* success cases, never remove one.
+      1. ``Item(index)`` — the historical path. Tried first so behaviour is
+         byte-for-byte identical on the (majority of) hosts where it already
+         works; this fix can only *add* success cases, never remove one.
       2. ``ElementAt(index)`` — SAP's documented integer accessor; accepted on
          hosts that reject ``Item``'s marshalled index.
       3. default member ``collection(index)`` — last resort; empirically accepted
@@ -91,7 +91,7 @@ def com_collection_item(com_collection: Any, index: int) -> Any:
     """
     try:
         return com_collection.Item(index)
-    except Exception as item_error:  # pylint: disable=broad-exception-caught
+    except Exception:  # pylint: disable=broad-exception-caught
         # ``getattr(..., None)`` returns a live method proxy for late-bound
         # CDispatch objects (so this branch is reached on real SAP hosts), and
         # ``None`` for plain objects that genuinely lack the method.
@@ -105,4 +105,8 @@ def com_collection_item(com_collection: Any, index: int) -> Any:
             return com_collection(index)  # default member: collection(index)
         except Exception:  # pylint: disable=broad-exception-caught
             pass
-        raise item_error
+        # Bare ``raise`` (not ``raise <saved exc>``) so the ORIGINAL traceback from
+        # the failed ``Item(index)`` call is preserved. Once the inner fallback
+        # handlers have completed, the exception being handled here is again the
+        # original ``Item`` error, so this re-raises it — not a fallback's error.
+        raise

--- a/src/sapsucker/_wrap.py
+++ b/src/sapsucker/_wrap.py
@@ -59,3 +59,50 @@ def wrap_com_object(com_obj: Any) -> GuiComponent:
             extra={"type_as_number": type_num, "com_type": getattr(com_obj, "Type", "?")},
         )
     return cls(com_obj)  # type: ignore[misc, no-any-return]
+
+
+def com_collection_item(com_collection: Any, index: int) -> Any:
+    """Return the raw COM element at *index* from a SAP GUI COM collection.
+
+    Works around SAP GUI COM error 618, ``"Bad index type for collection
+    access."``, which some hosts raise for ``collection.Item(<int>)`` under
+    pywin32 late binding **even when the collection is perfectly healthy**.
+
+    Observed on a fresh Windows 11 / SAP GUI 8.0 host (Hochfrequenz/sapgui.mcp#804):
+    ``connection.Children.Count == 1``, yet ``Children.Item(0)`` raises 618 while
+    ``Children(0)`` (the collection's default member) and ``Children.ElementAt(0)``
+    both return the element fine. The same code works on other hosts, so the
+    difference is in how the integer index is marshalled to ``Item`` — not the
+    collection, the element, or the server. This silently broke ``login()``:
+    ``wait_for_session`` reads ``conn.children[0]``, the ``Item`` call raised, and a
+    broad ``except`` swallowed it, so login spun to a 30s timeout with no session.
+
+    Strategy, in order (first that succeeds wins):
+      1. ``Item(index)`` — the historical path. Tried first so behaviour is byte
+         -for-byte identical on the (majority of) hosts where it already works;
+         this fix can only *add* success cases, never remove one.
+      2. ``ElementAt(index)`` — SAP's documented integer accessor; accepted on
+         hosts that reject ``Item``'s marshalled index.
+      3. default member ``collection(index)`` — last resort; empirically accepted
+         wherever ``ElementAt`` is.
+
+    If every strategy fails, the ORIGINAL ``Item`` error is re-raised, so a
+    genuinely bad index still surfaces its real COM error rather than a masked one.
+    """
+    try:
+        return com_collection.Item(index)
+    except Exception as item_error:  # pylint: disable=broad-exception-caught
+        # ``getattr(..., None)`` returns a live method proxy for late-bound
+        # CDispatch objects (so this branch is reached on real SAP hosts), and
+        # ``None`` for plain objects that genuinely lack the method.
+        element_at = getattr(com_collection, "ElementAt", None)
+        if element_at is not None:
+            try:
+                return element_at(index)
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+        try:
+            return com_collection(index)  # default member: collection(index)
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+        raise item_error

--- a/src/sapsucker/components/application.py
+++ b/src/sapsucker/components/application.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from sapsucker._wrap import wrap_com_object
+from sapsucker._wrap import com_collection_item, wrap_com_object
 from sapsucker.components.base import GuiContainer
 
 if TYPE_CHECKING:
@@ -116,7 +116,7 @@ class GuiApplication(GuiContainer):
             # so closing from the end avoids skipping connections.
             for i in range(self._com.Children.Count - 1, -1, -1):
                 try:
-                    self._com.Children.Item(i).CloseConnection()
+                    com_collection_item(self._com.Children, i).CloseConnection()
                 except Exception:  # noqa: BLE001
                     pass
         except Exception:  # noqa: BLE001

--- a/src/sapsucker/components/base.py
+++ b/src/sapsucker/components/base.py
@@ -10,7 +10,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from sapsucker._errors import ElementNotFoundError
-from sapsucker._wrap import wrap_com_object
+from sapsucker._wrap import com_collection_item, wrap_com_object
 
 if TYPE_CHECKING:
     from sapsucker.components.collection import GuiComponentCollection
@@ -275,7 +275,7 @@ def _probe_bdt_fields(com_obj: Any) -> list[ElementInfo]:
         try:
             found = com_obj.FindAllByNameEx("*", type_num)
             for j in range(found.Count):
-                child = found.Item(j)
+                child = com_collection_item(found, j)
                 child_id = str(_safe_com_attr(child, "Id", ""))
                 if child_id in seen_ids:
                     continue
@@ -506,7 +506,7 @@ def _dump_tree_recursive(com_obj: Any, depth: int, max_depth: int) -> list[Eleme
     if count > 0:
         for i in range(count):
             try:
-                child = children_com.Item(i)
+                child = com_collection_item(children_com, i)
             except Exception:
                 continue
             is_container = bool(_safe_com_attr(child, "ContainerType", False))

--- a/src/sapsucker/components/collection.py
+++ b/src/sapsucker/components/collection.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Iterator
 
-from sapsucker._wrap import wrap_com_object
+from sapsucker._wrap import com_collection_item, wrap_com_object
 from sapsucker.components.base import GuiComponent
 
 __all__ = ["GuiCollection", "GuiComponentCollection"]
@@ -27,7 +27,7 @@ class GuiComponentCollection:
             index += length
         if index < 0 or index >= length:
             raise IndexError(f"Index {index} out of range for collection of length {length}")
-        return wrap_com_object(self._com.Item(index))
+        return wrap_com_object(com_collection_item(self._com, index))
 
     def __iter__(self) -> Iterator[GuiComponent]:
         """Iterate over all wrapped components."""
@@ -55,12 +55,12 @@ class GuiCollection:
             index += length
         if index < 0 or index >= length:
             raise IndexError(f"Index {index} out of range for collection of length {length}")
-        return self._com.Item(index)
+        return com_collection_item(self._com, index)
 
     def __iter__(self) -> Iterator[Any]:
         """Iterate over all items."""
         for i in range(self._com.Count):
-            yield self._com.Item(i)
+            yield com_collection_item(self._com, i)
 
     def __repr__(self) -> str:
         return f"GuiCollection(count={self._com.Count})"

--- a/src/sapsucker/components/combobox.py
+++ b/src/sapsucker/components/combobox.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from sapsucker._wrap import com_collection_item
 from sapsucker.components.base import GuiVComponent
 
 __all__ = ["GuiComboBox", "GuiComboBoxEntry"]
@@ -54,7 +55,7 @@ class GuiComboBox(GuiVComponent):
         """Return all entries as a list of GuiComboBoxEntry."""
         result = []
         for i in range(self._com.Entries.Count):
-            result.append(GuiComboBoxEntry(self._com.Entries.Item(i)))
+            result.append(GuiComboBoxEntry(com_collection_item(self._com.Entries, i)))
         return result
 
     @property

--- a/src/sapsucker/login.py
+++ b/src/sapsucker/login.py
@@ -336,7 +336,12 @@ def wait_for_session(conn: Any, timeout: int = 30) -> GuiSession:
                 if isinstance(session, GuiSessionCls):
                     return session
         except Exception:
-            pass
+            # Tolerate transient errors while the session is still materialising,
+            # but log them: a persistent error here (e.g. the SAP GUI COM error 618
+            # "Bad index type" that ``conn.children[0]`` used to raise on some hosts,
+            # sapgui.mcp#804) would otherwise silently spin to the timeout below with
+            # no clue as to why. See ``com_collection_item`` for that specific fix.
+            logger.debug("wait_for_session_poll_error", exc_info=True)
         time.sleep(0.5)
     raise SapGuiTimeoutError(f"No session available on connection after {timeout}s")
 

--- a/unittests/test_collection.py
+++ b/unittests/test_collection.py
@@ -71,6 +71,27 @@ class TestGuiComponentCollection:
         assert len(gcc) == 0
         assert list(gcc) == []
 
+    def test_getitem_falls_back_when_item_raises_bad_index(self):
+        """Indexing still works when raw Item(i) raises SAP GUI error 618.
+
+        Regression guard for sapgui.mcp#804: on some hosts ``Item(<int>)`` raises
+        ``com_error`` 618 "Bad index type for collection access." while
+        ``ElementAt(<int>)`` returns the element fine. com_collection_item must
+        transparently fall back so ``collection[i]`` (and, through it, iteration)
+        keep working.
+        """
+        items = _make_component_items(2)
+        col = MagicMock()
+        col.Count = 2
+        col.Item.side_effect = RuntimeError("Bad index type for collection access.")
+        col.ElementAt = lambda i: items[i]
+
+        gcc = GuiComponentCollection(col)
+        assert gcc[0].com is items[0]
+        assert gcc[1].com is items[1]
+        # Iteration routes through __getitem__, so it recovers too.
+        assert [r.com for r in gcc] == items
+
 
 class TestGuiCollection:
     def test_len(self):

--- a/unittests/test_factory.py
+++ b/unittests/test_factory.py
@@ -9,6 +9,7 @@ from sapsucker._factory import (
     _TYPE_MAP,
     wrap_com_object,
 )
+from sapsucker._wrap import com_collection_item
 from sapsucker.components.base import GuiComponent
 from sapsucker.components.button import GuiButton
 from sapsucker.components.field import GuiTextField
@@ -94,3 +95,98 @@ class TestShellSubtypeMapCompleteness:
         com = make_mock_com(type_as_number=122, type_name="GuiShell", SubType=sub_type)
         result = wrap_com_object(com)
         assert isinstance(result, cls)
+
+
+class _FakeComError(Exception):
+    """Stand-in for pywintypes.com_error carrying SAP GUI error 618.
+
+    Mirrors the real payload observed on the failing host (sapgui.mcp#804):
+    ``(-2147352567, 'Exception occurred.', (618, 'saplogon',
+    'Bad index type for collection access.', None, 0, 0), None)``.
+    """
+
+
+_BAD_INDEX_ARGS = (
+    -2147352567,
+    "Exception occurred.",
+    (618, "saplogon", "Bad index type for collection access.", None, 0, 0),
+    None,
+)
+
+
+class _FakeCollection:
+    """Fake SAP GUI COM collection with independently-toggleable accessors.
+
+    Models the exact quirk from sapgui.mcp#804: ``Item(<int>)`` can raise COM
+    error 618 while ``ElementAt(<int>)`` and the default member ``collection(<int>)``
+    return the element fine.
+    """
+
+    def __init__(self, items, *, item_ok=True, element_at_ok=True, default_ok=True, has_element_at=True):
+        self._items = items
+        self._item_ok = item_ok
+        self._element_at_ok = element_at_ok
+        self._default_ok = default_ok
+        self._has_element_at = has_element_at
+        self.Count = len(items)
+
+    def Item(self, index):
+        if not self._item_ok:
+            raise _FakeComError(*_BAD_INDEX_ARGS)
+        return self._items[index]
+
+    def __call__(self, index):  # default member: collection(index)
+        if not self._default_ok:
+            raise _FakeComError(*_BAD_INDEX_ARGS)
+        return self._items[index]
+
+    def __getattr__(self, name):
+        # Only synthesise ElementAt; everything else is a genuine miss so that
+        # ``getattr(col, "ElementAt", None)`` returns None when absent.
+        if name == "ElementAt" and self.__dict__.get("_has_element_at", False):
+
+            def _element_at(index):
+                if not self._element_at_ok:
+                    raise _FakeComError(*_BAD_INDEX_ARGS)
+                return self._items[index]
+
+            return _element_at
+        raise AttributeError(name)
+
+
+class TestComCollectionItem:
+    """Tests for com_collection_item() — the SAP GUI error 618 workaround (mcp#804)."""
+
+    def test_uses_item_when_it_works(self):
+        """When Item(index) succeeds it is used and ElementAt is never consulted."""
+        items = ["a", "b", "c"]
+        # ElementAt would raise if reached — proves it is not reached.
+        col = _FakeCollection(items, item_ok=True, element_at_ok=False)
+        assert com_collection_item(col, 1) == "b"
+
+    def test_falls_back_to_element_at_on_bad_index(self):
+        """Item raising 618 falls back to ElementAt(index)."""
+        items = ["a", "b", "c"]
+        col = _FakeCollection(items, item_ok=False, element_at_ok=True)
+        assert com_collection_item(col, 2) == "c"
+
+    def test_falls_back_to_default_member_when_item_and_element_at_fail(self):
+        """Item and ElementAt both raising falls back to the default member call."""
+        items = ["a", "b", "c"]
+        col = _FakeCollection(items, item_ok=False, element_at_ok=False, default_ok=True)
+        assert com_collection_item(col, 0) == "a"
+
+    def test_falls_back_to_default_member_when_element_at_absent(self):
+        """A collection without ElementAt falls straight to the default member."""
+        items = ["a", "b"]
+        col = _FakeCollection(items, item_ok=False, has_element_at=False, default_ok=True)
+        assert com_collection_item(col, 1) == "b"
+
+    def test_reraises_original_item_error_when_all_strategies_fail(self):
+        """If every access strategy fails, the ORIGINAL Item error is re-raised."""
+        col = _FakeCollection(["a"], item_ok=False, element_at_ok=False, default_ok=False)
+        with pytest.raises(_FakeComError) as exc_info:
+            com_collection_item(col, 0)
+        # The re-raised error is the one from Item (carries the 618 payload), not a
+        # masked/replaced exception from a later fallback.
+        assert exc_info.value.args[2][0] == 618

--- a/unittests/test_login.py
+++ b/unittests/test_login.py
@@ -597,3 +597,30 @@ class TestWaitForSession:
 
         with pytest.raises(SapGuiTimeoutError, match="No session available"):
             wait_for_session(_RaisingConn(), timeout=1)
+
+    def test_returns_session_when_raw_children_item_raises_bad_index(self):
+        """End-to-end regression guard for sapgui.mcp#804.
+
+        On the failing host ``connection.Children.Count == 1`` but the raw
+        ``Children.Item(0)`` raises SAP GUI error 618 "Bad index type for
+        collection access.", which the old poll loop swallowed and spun to a
+        timeout. Driving the REAL GuiConnection -> GuiComponentCollection ->
+        com_collection_item path, wait_for_session must now recover via the
+        ElementAt fallback and return the session.
+        """
+        from sapsucker.components.connection import GuiConnection
+        from sapsucker.components.session import GuiSession as GuiSessionCls
+        from unittests.conftest import make_mock_com
+
+        session_com = make_mock_com(type_as_number=12, type_name="GuiSession", name="ses[0]")
+        children = MagicMock()
+        children.Count = 1
+        children.Item.side_effect = RuntimeError("Bad index type for collection access.")
+        children.ElementAt = lambda i: session_com
+        conn_com = MagicMock()
+        conn_com.DisabledByServer = False
+        conn_com.Children = children
+
+        result = wait_for_session(GuiConnection(conn_com), timeout=2)
+        assert isinstance(result, GuiSessionCls)
+        assert result.com is session_com


### PR DESCRIPTION
## Problem

On some Windows / SAP GUI for Windows hosts, calling `Item(<int>)` on a SAP GUI
`GuiComponentCollection` under pywin32 late binding raises:

```
com_error: (-2147352567, 'Exception occurred.',
  (618, 'saplogon', 'Bad index type for collection access.', None, 0, 0), None)
```

…**even though the collection is perfectly healthy.** On the affected host,
immediately after opening a connection:

| Access | Result |
|---|---|
| `connection.Children.Count` | `1` |
| `connection.Children.Item(0)` | ❌ com_error **618** "Bad index type for collection access." |
| `connection.Children.Item(1)` | ❌ 618 |
| `connection.Children.Item('ses[0]')` | ❌ 618 |
| `connection.Children(0)` (default member) | ✅ returns the `GuiSession` (`TypeAsNumber=12`) |
| `connection.Children.ElementAt(0)` | ✅ returns the `GuiSession` |
| `connection.FindById('ses[0]')` | ✅ returns the `GuiSession` |
| iterating the collection | ✅ returns the `GuiSession` |

The same sapsucker code works on other hosts, so the difference is purely in how
the integer index is marshalled to `Item` on this host — not the collection, the
element, or the server (`DisabledByServer=False`, `Count=1`, at t=0s).

### User-visible impact

`GuiComponentCollection.__getitem__` used `self._com.Item(index)`, so
`wait_for_session()` — which reads `conn.children[0]` — raised the com_error,
which the poll loop's broad `except Exception: pass` swallowed. Desktop login
therefore opened the connection (login window appears) but **spun to a 30s
`No session available on connection after 30s` timeout and never entered
credentials.** A raw single-threaded `win32com` probe that only read
`Children.Count` succeeded on the same host, which is why this looked like an
environment issue for a while — the raw read never exercised `Item(0)`.

Root-caused with an instrumented probe that reproduced it via the real sapsucker
read path and printed the exact failing COM call. Threading / STA message-pump
theories were tested and **ruled out** (the failure is identical on the main
thread, and pumping the message queue does not help).

## Fix

Centralise integer indexing of COM collections in a new helper
`com_collection_item(collection, index)` (`_wrap.py`) that:

1. tries `Item(index)` first — so behaviour is byte-for-byte identical on hosts
   where it already works (this change can only *add* success cases, never
   remove one);
2. falls back to `ElementAt(index)` — SAP's documented integer accessor;
3. falls back to the default member `collection(index)`;
4. re-raises the **original** `Item` error if all strategies fail, so a
   genuinely bad index still surfaces its real COM error rather than a masked one.

Every integer-indexed COM collection access is routed through it
(`GuiComponentCollection`, `GuiCollection`, application connection cleanup,
combobox entries, the BDT field probe, and `dump_tree`), so this is fixed
library-wide, not just for login.

Also: `wait_for_session()` now logs the previously-swallowed poll error at DEBUG,
so a future persistent failure here is diagnosable instead of an opaque timeout.

The `ElementAt` / default-member fallbacks are **empirically confirmed on the
affected host** to return the `GuiSession` that `Item` rejects.

## Tests

- `com_collection_item` fallback order (Item → ElementAt → default member) and
  the "re-raise the original `Item` error when all fail" semantics.
- `GuiComponentCollection[i]` and iteration recover when the raw `Item(i)` raises.
- End-to-end regression guard: `wait_for_session` driving the real
  `GuiConnection → GuiComponentCollection → com_collection_item` path returns the
  session when the raw `Children.Item(0)` raises error 618.

Full suite green (544 passed), `black`/`isort` clean, `mypy --strict` clean,
`pylint` 10/10.

Fixes the sapsucker side of Hochfrequenz/sapgui.mcp#804.
